### PR TITLE
Allow dashes in team prefixes

### DIFF
--- a/scrummasterjr/jira.py
+++ b/scrummasterjr/jira.py
@@ -782,7 +782,7 @@ class Jira:
 
     def updateSummary(self, tag):
         logging.info(f"Found Summary Update Tag: {tag}")
-        results = re.search('\[(?P<tag>[\w-]+) (?P<value>[\d\.]+)( (?P<arg>[\w\.]+))?( (?P<arg2>[\d\.]+))?( (?P<arg3>[\d\.]+))?\]', tag)
+        results = re.search('\[(?P<tag>[\w-]+) (?P<value>[\d\.]+)( (?P<arg>[\w\-.]+))?( (?P<arg2>[\d\.]+))?( (?P<arg3>[\d\.]+))?\]', tag)
         if results:
             if results.group('tag') == 'sprint':
                 return self.setSummaryCurrentSprint(results.group('value'))


### PR DESCRIPTION
The code that parses the team prefix from the Confluence tag wasn't expecting a `-` like Platform - Scalability has with `O2-S`. This alters the regex so it will match on fields with `-` in them