### PR TITLE
Sort keys as integers and not strings

### DIFF
--- a/scrummasterjr/jira.py
+++ b/scrummasterjr/jira.py
@@ -465,7 +465,7 @@ class Jira:
 
         sprint_id = f"{sprint_id}"
 
-        for sprint in sorted(velocity_report['velocityStatEntries'], reverse=True):
+        for sprint in sorted(velocity_report['velocityStatEntries'], reverse=True, key=int):
             if sprints >= 3:
                 # We only care about the last three sprints
                 break;


### PR DESCRIPTION
We were sorting these keys (sprint ids) as if they were strings, because they are. This hasn't caused an issue until we've reached high enough that there's a new digit. The string "5678" is larger than "12345" but obviously those should be reversed. Explicitly casting them as integers resolves that.