### PR TITLE
Use Previous Report Dates

### DIFF
--- a/generate_eos_report_page.py
+++ b/generate_eos_report_page.py
@@ -37,8 +37,8 @@ if __name__ == '__main__':
         next_sprint = f"{now.strftime('%y')}.{current_sprint_number+1:02}"
         previous_sprint = f"{now.strftime('%y')}.{current_sprint_number-1:02}"
         
-        start_date = (now-datetime.timedelta(days=12)).strftime('%m/%d')
-        end_date = (now+datetime.timedelta(days=2)).strftime('%m/%d')
+        start_date = previous_end.strftime('%m/%d')
+        end_date = (previous_end+datetime.timedelta(days=14)).strftime('%m/%d')
 
         source = confluence.get_page_by_id(template_page_id, expand='body.storage')
         newbody = source['body']['storage']['value']


### PR DESCRIPTION
Instead of using the time the action is run to determine the dates of the next sprint report, use the dates from the previous run